### PR TITLE
feat: add `getLatestVersion` and `getAllVersions`

### DIFF
--- a/src/detectors.ts
+++ b/src/detectors.ts
@@ -1,7 +1,7 @@
 import { readFile as nodeReadFile } from "node:fs/promises";
 import semver from "semver";
 import yaml from "yaml";
-import { fetchBiomeVersions } from "./versions";
+import { getAllVersions } from "./versions";
 
 /**
  * Detects the version of Biome from the dependencies of the project.
@@ -155,7 +155,7 @@ export const detectFromPackageJson = async (
 		// versions from the npm registry and return the latest version that
 		// satisfies the range.
 		if (semver.validRange(versionSpecifier)) {
-			const versions = await fetchBiomeVersions();
+			const versions = await getAllVersions();
 
 			// If we are unable to fetch the list of Biome versions, we return
 			// undefined.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./detectors";
+export * from "./versions";

--- a/src/versions.ts
+++ b/src/versions.ts
@@ -1,7 +1,22 @@
 import semver, { type SemVer, rsort } from "semver";
 import { request } from "undici";
 
-export const fetchBiomeVersions = async (): Promise<string[] | undefined> => {
+/**
+ * Retrieves the latest version of Biome from the npm registry.
+ */
+export const getLatestVersion = async (): Promise<string | undefined> => {
+	try {
+		const versions = await getAllVersions();
+		return versions?.[0];
+	} catch {
+		return undefined;
+	}
+};
+
+/**
+ * Fetches the list of Biome versions from the npm registry.
+ */
+export const getAllVersions = async (): Promise<string[] | undefined> => {
 	try {
 		const response = await request(
 			"https://registry.npmjs.org/@biomejs/biome",

--- a/test/suites/detector.test.ts
+++ b/test/suites/detector.test.ts
@@ -9,12 +9,12 @@ import {
 } from "../../src";
 
 const mocks = {
-	fetchBiomeVersions: mock(),
+	getAllVersions: mock(),
 };
 
 mock.module("../../src/versions", () => {
 	return {
-		fetchBiomeVersions: mocks.fetchBiomeVersions,
+		getAllVersions: mocks.getAllVersions,
 	};
 });
 
@@ -150,7 +150,7 @@ describe("detector", () => {
 	it("retrieves the latest version in range from the npm registry", async () => {
 		// We mock the response from the NPM registry so the test is deterministic
 		// even if the version of the package changes
-		mocks.fetchBiomeVersions.mockResolvedValue(["1.6.2", "1.6.3", "1.6.4"]);
+		mocks.getAllVersions.mockResolvedValue(["1.6.4", "1.6.3", "1.6.2"]);
 
 		const version = await detectFromPackageJson(
 			join(__dirname, "../fixtures/npm/devDependencies/package.json"),


### PR DESCRIPTION
This PR adds two new methods:

- `getLatestVersion`, which returns the latest version of Biome
- `getAllVersions`, which returns the list of all Biome versions, sorted in descending order (latest first).